### PR TITLE
split naming of emea and europe

### DIFF
--- a/stage_2_configuration/full_config/.meta-cnc.yaml
+++ b/stage_2_configuration/full_config/.meta-cnc.yaml
@@ -57,7 +57,7 @@ variables:
       - key: North America & South America
         value: americas
       - key: Africa, Europe & Middle East
-        value: emea
+        value: europe
       - key: Asia, Australia & Japan
         value: apac
     help_text: skillet allows for selecting a single starter region. additional regions or worldwide added in Panorama GUI
@@ -123,12 +123,12 @@ variables:
       - key: Venezuela
         value: venezuela
 
-  - name: deployment_locations_emea
+  - name: deployment_locations_europe
     description: deployment locations for Africa, Europe & Middle East
     default: eu-west-1
     toggle_hint:
       source: deployment_region
-      value: emea
+      value: europe
     type_hint: checkbox
     help_text: Select the regions where you want to deploy Prisma Access; use the GUI to select all or check for recently added locations
     cbx_list:

--- a/stage_2_configuration/full_config/prisma_access_full_config_vars.conf
+++ b/stage_2_configuration/full_config/prisma_access_full_config_vars.conf
@@ -1127,6 +1127,9 @@
                 </default-domain>
               </portal-hostname>
               <ip-pools>
+               {% if deployment_region == 'europe' %}
+               {%- set deployment_region = 'emea' %}
+               {% endif %}
                 <entry name="{{ deployment_region }}">
                   <ip-pool>
                     <member>{{ ip_pool_cidr }}</member>
@@ -1142,12 +1145,15 @@
               <global-protect-gateway>GlobalProtect_External_Gateway</global-protect-gateway>
               <deployment>
                 <region>
+               {% if deployment_region == 'emea' %}
+               {%- set deployment_region = 'europe' %}
+               {% endif %}
                   <entry name="{{ deployment_region }}">
                     <locations>
                       {%- if deployment_region == 'americas' %}
                         {%- set deployment_locations = deployment_locations_americas %}
-                      {% elif deployment_region == 'emea' %}
-                        {%- set deployment_locations = deployment_locations_emea %}
+                      {% elif deployment_region == 'europe' %}
+                        {%- set deployment_locations = deployment_locations_europe %}
                       {% elif deployment_region == 'apac' %}
                         {%- set deployment_locations = deployment_locations_apac %}
                       {% endif %}
@@ -1164,8 +1170,8 @@
                     <locations>
                       {%- if deployment_region == 'americas' %}
                         {%- set deployment_locations = deployment_locations_americas %}
-                      {% elif deployment_region == 'emea' %}
-                        {%- set deployment_locations = deployment_locations_emea %}
+                      {% elif deployment_region == 'europe' %}
+                        {%- set deployment_locations = deployment_locations_europe %}
                       {% elif deployment_region == 'apac' %}
                         {%- set deployment_locations = deployment_locations_apac %}
                       {% endif %}

--- a/stage_2_configuration/render_and_import_file/.meta-cnc.yaml
+++ b/stage_2_configuration/render_and_import_file/.meta-cnc.yaml
@@ -61,7 +61,7 @@ variables:
       - key: North America & South America
         value: americas
       - key: Africa, Europe & Middle East
-        value: emea
+        value: europe
       - key: Asia, Australia & Japan
         value: apac
     help_text: skillet allows for selecting a single starter region. additional regions or worldwide added in Panorama GUI
@@ -127,12 +127,12 @@ variables:
       - key: Venezuela
         value: venezuela
 
-  - name: deployment_locations_emea
+  - name: deployment_locations_europe
     description: deployment locations for Africa, Europe & Middle East
     default: eu-west-1
     toggle_hint:
       source: deployment_region
-      value: emea
+      value: europe
     type_hint: checkbox
     help_text: Select the regions where you want to deploy Prisma Access; use the GUI to select all or check for recently added locations
     cbx_list:

--- a/stage_2_configuration/render_and_import_file/render_and_import_file.py
+++ b/stage_2_configuration/render_and_import_file/render_and_import_file.py
@@ -33,7 +33,7 @@ from skilletlib.exceptions import SkilletLoaderException
 @click.option("-reg", "--deployment_region", help="deployment region", type=str, default="americas")
 @click.option("-lam", "--deployment_locations_americas", help="deployment locations americas", type=str,
               default="us-east-1, us-west-1")
-@click.option("-leu", "--deployment_locations_emea", help="deployment locations emea", type=str,
+@click.option("-leu", "--deployment_locations_europe", help="deployment locations europe", type=str,
               default="eu-west-1")
 @click.option("-lap", "--deployment_locations_apac", help="deployment locations apac", type=str,
               default="australia-east")
@@ -43,7 +43,7 @@ from skilletlib.exceptions import SkilletLoaderException
 @click.option("-f", "--conf_filename", help="Configuration File Name", type=str,
               default="prisma_access_full_config.xml")
 def cli(target_ip, target_port, target_username, target_password, infra_subnet, infra_bgp_as,
-        portal_hostname, deployment_region, deployment_locations_americas, deployment_locations_emea,
+        portal_hostname, deployment_region, deployment_locations_americas, deployment_locations_europe,
         deployment_locations_apac, ip_pool_cidr, user1_password, user2_password, conf_filename):
     """
     Import a full configuration. Defaults values in parenthesis.
@@ -56,7 +56,7 @@ def cli(target_ip, target_port, target_username, target_password, infra_subnet, 
     context['portal_hostname'] = portal_hostname
     context['deployment_region'] = deployment_region
     context['deployment_locations_americas'] = deployment_locations_americas.split(',')
-    context['deployment_locations_emea'] = deployment_locations_emea.split(',')
+    context['deployment_locations_europe'] = deployment_locations_europe.split(',')
     context['deployment_locations_apac'] = deployment_locations_apac.split(',')
     context['ip_pool_cidr'] = ip_pool_cidr
     context['user1_password'] = user1_password
@@ -70,6 +70,8 @@ def cli(target_ip, target_port, target_username, target_password, infra_subnet, 
         skillet = sl.load_skillet_from_path('../full_config')
         output = skillet.execute(context)
         file_contents = output.get('template', '')
+
+        print(output)
 
         # create device object and use panoply import_file to send a config file to the device
         device = Panos(api_username=target_username,


### PR DESCRIPTION
discovered that the europe config uses both europe and emea while americas/apac are consistent. Had to update the jinja template to use both names without requiring additional variables.
